### PR TITLE
Improve authentication process

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/jsLibraryMappings.xml
+++ b/.idea/jsLibraryMappings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JavaScriptLibraryMappings">
+    <includedPredefinedLibrary name="Node.js Core" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/node-red-spotify.iml" filepath="$PROJECT_DIR$/.idea/node-red-spotify.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/node-red-spotify.iml
+++ b/.idea/node-red-spotify.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.tmp" />
+      <excludeFolder url="file://$MODULE_DIR$/temp" />
+      <excludeFolder url="file://$MODULE_DIR$/tmp" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/runConfigurations/Docker_Dev.xml
+++ b/.idea/runConfigurations/Docker_Dev.xml
@@ -10,6 +10,10 @@
               <option name="containerPort" value="1880" />
               <option name="hostPort" value="1880" />
             </DockerPortBindingImpl>
+            <DockerPortBindingImpl>
+              <option name="containerPort" value="9229" />
+              <option name="hostPort" value="9229" />
+            </DockerPortBindingImpl>
           </list>
         </option>
         <option name="sourceFilePath" value="Dockerfile" />

--- a/.idea/runConfigurations/Docker_Dev.xml
+++ b/.idea/runConfigurations/Docker_Dev.xml
@@ -1,0 +1,28 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Docker Dev" type="docker-deploy" factoryName="dockerfile" server-name="Docker">
+    <deployment type="dockerfile">
+      <settings>
+        <option name="imageTag" value="node-red-spotify:latest" />
+        <option name="containerName" value="node-red-dev" />
+        <option name="portBindings">
+          <list>
+            <DockerPortBindingImpl>
+              <option name="containerPort" value="1880" />
+              <option name="hostPort" value="1880" />
+            </DockerPortBindingImpl>
+          </list>
+        </option>
+        <option name="sourceFilePath" value="Dockerfile" />
+        <option name="volumeBindings">
+          <list>
+            <DockerVolumeBindingImpl>
+              <option name="containerPath" value="/data" />
+              <option name="hostPath" value="node_red_data2" />
+            </DockerVolumeBindingImpl>
+          </list>
+        </option>
+      </settings>
+    </deployment>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,3 +2,15 @@ FROM nodered/node-red:4.0.5-22-minimal
 
 COPY . /tmp/node-red-spotify
 RUN npm install /tmp/node-red-spotify
+
+# Debugging section
+#
+# 1. Bind port 9229 to localhost
+# 2. Uncomment entrypoint:
+# ENTRYPOINT ["npm"]
+#
+# 3a. Uncomment below CMD for breaking immediately after Node-RED start.
+# CMD ["run", "debug_brk", "--", "--userDir", "/data"]
+#
+# 3b. OR uncomment below CMD for casual debugging.
+# CMD ["run", "debug", "--", "--userDir", "/data"]

--- a/lib/credentials.js
+++ b/lib/credentials.js
@@ -1,0 +1,69 @@
+const path = require("node:path");
+const fs = require("node:fs");
+const crypto = require("node:crypto");
+
+const encryptionAlgorithm = "aes-256-ctr";
+
+function decryptCredentials(key, cryptJson) {
+  let cipher = JSON.parse(cryptJson)["$"];
+  const initVector = Buffer.from(cipher.substring(0, 32), 'hex');
+  cipher = cipher.substring(32);
+
+  const decipher = crypto.createDecipheriv(encryptionAlgorithm, key,
+      initVector);
+  const decrypted = decipher.update(cipher, 'base64', 'utf8') + decipher.final(
+      'utf8');
+  return JSON.parse(decrypted);
+}
+
+function encryptCredentials(key, credentials) {
+  const initVector = crypto.randomBytes(16);
+  const cipher = crypto.createCipheriv(encryptionAlgorithm, key, initVector);
+
+  return JSON.stringify({
+    "$": initVector.toString('hex') + cipher.update(
+        JSON.stringify(credentials), 'utf8', 'base64') + cipher.final(
+        'base64')
+  });
+}
+
+function getKey(node) {
+  const key = node?.credentials?.clientSecret;
+  if (!key) {
+    throw new Error("The secret key is missing");
+  }
+
+  return key;
+}
+
+function getCredentialsFile(node, RED) {
+  const dir = path.join(RED.settings.userDir, ".node-red-spotify")
+  const file = path.join(dir, node.id);
+
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir)
+  }
+
+  return file;
+}
+
+module.exports = {
+  getCredentials: function(node, RED) {
+    const file = getCredentialsFile(node, RED);
+    if (!fs.existsSync(file)) {
+      return {};
+    }
+
+    return decryptCredentials(getKey(node), fs.readFileSync(file).toString());
+  },
+
+  setCredentials: function(credentials, node, RED) {
+    fs.writeFileSync(
+        getCredentialsFile(node, RED),
+        encryptCredentials(getKey(node), credentials));
+  },
+
+  removeCredentials: function(node, RED) {
+    fs.rmSync(getCredentialsFile(node, RED));
+  }
+}

--- a/lib/success-page.js
+++ b/lib/success-page.js
@@ -1,0 +1,33 @@
+module.exports = `
+<html lang="en">
+<head>
+  <title>Authentication successful</title>
+  <style>
+    body {
+      padding: 4em;
+    }
+
+    #content {
+      width: 100%;
+      height: 100%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      text-align: center;
+      font-size: 2.5em;
+      font-family: sans-serif;
+    }
+  </style>
+</head>
+<body>
+<script type="text/javascript">
+  (() => {
+    setTimeout(() => window.close(), 2500); 
+  })();
+</script>
+<div id="content">
+  <h3>Authentication successful, the window will close shortly</h3>
+</div>
+</body>
+</html>
+`

--- a/nodes/spotify-api.html
+++ b/nodes/spotify-api.html
@@ -1,5 +1,6 @@
 <script type="text/javascript">
   (() => {
+    const pollInterval = 2000;
     let pollTimeout = null;
 
     function getAuthorizationParams(state) {
@@ -22,22 +23,14 @@
       }).toString()).then(res => {
         if (res.status === 200) {
           // OAuth flow was successful, the tokens are in the response body
-          return res.json();
+          RED.notify("Authentication successful. You can save the configuration now.",
+              {type: "success"});
         } else if (res.status === 202) {
-          // Request was valid, but the authorization code hadn't been received yet
-          return Promise.resolve({});
+          // Request was valid, but the authorization code hadn't been received yet, so keep polling
+          pollTimeout = setTimeout(() => getTokens(state, nodeId), pollInterval);
         } else {
           // Unknown response
           return Promise.reject(res.status);
-        }
-      }).then(json => {
-        if ("tokens" in json) {
-          $("#node-config-input-refreshToken").val(json.tokens.refresh_token);
-
-          RED.notify("Authentication successful. You can save the configuration now.",
-              {type: "success"});
-        } else {
-          pollTimeout = setTimeout(() => getTokens(state, nodeId), 2000);
         }
       }).catch(err => {
         RED.notify("Authentication error: " + err, {type: "error"});
@@ -47,14 +40,19 @@
     function signInCallback(nodeId) {
       const state = crypto.randomUUID();
 
-      pollTimeout = setTimeout(() => getTokens(state, nodeId), 2000);
-      window.open("https://accounts.spotify.com/authorize?" + getAuthorizationParams(state));
+      pollTimeout = setTimeout(() => getTokens(state, nodeId), pollInterval);
+      window.open("https://accounts.spotify.com/authorize?" + getAuthorizationParams(state),
+          "popup=true");
     }
 
-    function isValidPristine(node) {
+    function isConfigurationSaved(node) {
       return node.id !== null
           && node.credentials.has_clientSecret
           && !node.credentials.clientSecret;
+    }
+
+    function onEditorLeave() {
+      clearTimeout(pollTimeout);
     }
 
     RED.nodes.registerType('spotify-api', {
@@ -69,14 +67,13 @@
         // data.
         redirectUri: {required: true, type: "text"},
         clientId: {required: true, type: "text"},
-        clientSecret: {required: true, type: "password"},
-        refreshToken: {type: "password"},
+        clientSecret: {required: true, type: "password"}
       },
       label: function () {
         return this.name || "New Spotify API";
       },
-      oneditcancel: () => clearTimeout(pollTimeout),
-      oneditsave: () => clearTimeout(pollTimeout),
+      oneditcancel: onEditorLeave,
+      oneditsave: onEditorLeave,
       oneditprepare: function () {
         const node = this;
         debugger;
@@ -84,7 +81,7 @@
         // TODO: Get rid of that hardcoded URI.
         $("#node-config-input-redirectUri").val("http://localhost:1880/spotify/oauth");
 
-        if (isValidPristine(node)) {
+        if (isConfigurationSaved(node)) {
           $("#sign-in").on("click", () => signInCallback(node.id));
         } else {
           $("#sign-in").prop("disabled", true);
@@ -97,8 +94,8 @@
 
 <script type="text/html" data-template-name="spotify-api">
   <div class="form-row">
-    <h2>API configuration</h2>
-    <div>The fields in this section are mandatory, and must be provided manually before initiating
+    <div>
+      The fields in this section are mandatory, and must be provided manually before initiating
       OAuth flow.
     </div>
   </div>
@@ -125,15 +122,5 @@
       process, you have to save the configuration node first, deploy your changes, edit it the
       configuration node again, and then the button will be active.
     </p>
-  </div>
-  <div class="form-row">
-    <h2>Tokens</h2>
-    <div>
-      The refresh token will be populated automatically upon a successful OAuth authentication.
-    </div>
-  </div>
-  <div class="form-row">
-    <label for="node-config-input-refreshToken"><i class="fa fa-refresh"></i> Refresh token</label>
-    <input type="password" id="node-config-input-refreshToken" readonly>
   </div>
 </script>

--- a/nodes/spotify-api.html
+++ b/nodes/spotify-api.html
@@ -1,11 +1,13 @@
 <script type="text/javascript">
   (() => {
+    let pollTimeout = null;
+
     function getAuthorizationParams(state) {
       const params = new URLSearchParams();
 
-      params.append("client_id", $("#node-config-input-client_id").val());
+      params.append("client_id", $("#node-config-input-clientId").val());
       params.append("response_type", "code");
-      params.append("redirect_uri", $("#node-config-input-redirect_uri").val());
+      params.append("redirect_uri", $("#node-config-input-redirectUri").val());
       params.append("state", state);
       params.append("scope",
           "user-modify-playback-state,user-read-playback-state,user-read-currently-playing");
@@ -13,11 +15,10 @@
       return params.toString();
     }
 
-    function getTokens(state) {
+    function getTokens(state, nodeId) {
       fetch("/spotify/oauth/continue?" + new URLSearchParams({
-        client_id: $("#node-config-input-client_id").val(),
-        state: state,
-        secret: $("#node-config-input-client_secret").val()
+        state,
+        nodeId
       }).toString()).then(res => {
         if (res.status === 200) {
           // OAuth flow was successful, the tokens are in the response body
@@ -30,24 +31,30 @@
           return Promise.reject(res.status);
         }
       }).then(json => {
-        if ("credentials" in json) {
-          $("#node-config-input-access_token").val(json.credentials.access_token);
-          $("#node-config-input-refresh_token").val(json.credentials.refresh_token);
+        if ("tokens" in json) {
+          $("#node-config-input-refreshToken").val(json.tokens.refresh_token);
 
-          RED.notify("Authentication successful. You can save the configuration now.", {type: "success"});
+          RED.notify("Authentication successful. You can save the configuration now.",
+              {type: "success"});
         } else {
-          setTimeout(() => getTokens(state), 2000);
+          pollTimeout = setTimeout(() => getTokens(state, nodeId), 2000);
         }
       }).catch(err => {
         RED.notify("Authentication error: " + err, {type: "error"});
       });
     }
 
-    function signInCallback() {
+    function signInCallback(nodeId) {
       const state = crypto.randomUUID();
 
-      setTimeout(() => getTokens(state), 2000);
+      pollTimeout = setTimeout(() => getTokens(state, nodeId), 2000);
       window.open("https://accounts.spotify.com/authorize?" + getAuthorizationParams(state));
+    }
+
+    function isValidPristine(node) {
+      return node.id !== null
+          && node.credentials.has_clientSecret
+          && !node.credentials.clientSecret;
     }
 
     RED.nodes.registerType('spotify-api', {
@@ -55,19 +62,34 @@
       defaults: {
         name: {value: "My Spotify API", required: true}
       },
+      // Access token should not be a part of credentials, because it changes frequently anyway.
+      // The parameters below are enough to request new access tokens anytime we want.
       credentials: {
-        client_id: {required: true},
-        redirect_uri: {required: true},
-        client_secret: {required: true, type: "password"},
-        access_token: {required: true, type: "password"},
-        refresh_token: {required: true, type: "password"},
+        // Redirect URI and Client ID can be ordinary text fields because they aren't sensitive
+        // data.
+        redirectUri: {required: true, type: "text"},
+        clientId: {required: true, type: "text"},
+        clientSecret: {required: true, type: "password"},
+        refreshToken: {type: "password"},
       },
       label: function () {
         return this.name || "New Spotify API";
       },
+      oneditcancel: () => clearTimeout(pollTimeout),
+      oneditsave: () => clearTimeout(pollTimeout),
       oneditprepare: function () {
-        $("#node-config-input-redirect_uri").val("http://localhost:1880/spotify/oauth");
-        $("#sign-in").on("click", signInCallback);
+        const node = this;
+        debugger;
+
+        // TODO: Get rid of that hardcoded URI.
+        $("#node-config-input-redirectUri").val("http://localhost:1880/spotify/oauth");
+
+        if (isValidPristine(node)) {
+          $("#sign-in").on("click", () => signInCallback(node.id));
+        } else {
+          $("#sign-in").prop("disabled", true);
+          $("#new-data-warning").removeClass("hide");
+        }
       }
     });
   })();
@@ -85,32 +107,33 @@
     <input type="text" id="node-config-input-name">
   </div>
   <div class="form-row">
-    <label for="node-config-input-client_id"><i class="fa fa-id-badge"></i> Client ID</label>
-    <input type="text" id="node-config-input-client_id">
+    <label for="node-config-input-redirectUri"><i class="fa fa-undo"></i> Redirect URI</label>
+    <input type="text" id="node-config-input-redirectUri" readonly>
   </div>
   <div class="form-row">
-    <label for="node-config-input-redirect_uri"><i class="fa fa-undo"></i> Redirect URI</label>
-    <input type="text" id="node-config-input-redirect_uri" readonly>
+    <label for="node-config-input-clientId"><i class="fa fa-id-badge"></i> Client ID</label>
+    <input type="text" id="node-config-input-clientId">
   </div>
   <div class="form-row">
-    <label for="node-config-input-client_secret"><i class="fa fa-key"></i> Client secret</label>
-    <input type="password" id="node-config-input-client_secret">
+    <label for="node-config-input-clientSecret"><i class="fa fa-key"></i> Client secret</label>
+    <input type="password" id="node-config-input-clientSecret">
   </div>
   <div class="form-row">
     <button id="sign-in" type="button" class="red-ui-button">Sign in to Spotify</button>
+    <p id="new-data-warning" class="hide">
+      It looks like you've provided new credentials. Before you can initiate the authentication
+      process, you have to save the configuration node first, deploy your changes, edit it the
+      configuration node again, and then the button will be active.
+    </p>
   </div>
   <div class="form-row">
     <h2>Tokens</h2>
-    <div>Access token and refresh token will be populated automatically upon a successful OAuth
-      authentication.
+    <div>
+      The refresh token will be populated automatically upon a successful OAuth authentication.
     </div>
   </div>
   <div class="form-row">
-    <label for="node-config-input-access_token"><i class="fa fa-lock"></i> Access token</label>
-    <input type="password" id="node-config-input-access_token" readonly>
-  </div>
-  <div class="form-row">
-    <label for="node-config-input-refresh_token"><i class="fa fa-refresh"></i> Refresh token</label>
-    <input type="password" id="node-config-input-refresh_token" readonly>
+    <label for="node-config-input-refreshToken"><i class="fa fa-refresh"></i> Refresh token</label>
+    <input type="password" id="node-config-input-refreshToken" readonly>
   </div>
 </script>

--- a/nodes/spotify-api.html
+++ b/nodes/spotify-api.html
@@ -1,6 +1,6 @@
 <script type="text/javascript">
   (() => {
-    const pollInterval = 2000;
+    const pollInterval = 1000;
     let pollTimeout = null;
 
     function getAuthorizationParams(state) {
@@ -23,6 +23,7 @@
       }).toString()).then(res => {
         if (res.status === 200) {
           // OAuth flow was successful, the tokens are in the response body
+          $("#node-config-input-oauth").val("AUTH_COMPLETE");
           RED.notify("Authentication successful. You can save the configuration now.",
               {type: "success"});
         } else if (res.status === 202) {
@@ -58,7 +59,8 @@
     RED.nodes.registerType('spotify-api', {
       category: 'config',
       defaults: {
-        name: {value: "My Spotify API", required: true}
+        name: {label: "Name", value: "My Spotify API", required: true},
+        oauth: {label: "OAuth linking", value: "", required: true},
       },
       // Access token should not be a part of credentials, because it changes frequently anyway.
       // The parameters below are enough to request new access tokens anytime we want.
@@ -76,7 +78,6 @@
       oneditsave: onEditorLeave,
       oneditprepare: function () {
         const node = this;
-        debugger;
 
         // TODO: Get rid of that hardcoded URI.
         $("#node-config-input-redirectUri").val("http://localhost:1880/spotify/oauth");
@@ -122,5 +123,8 @@
       process, you have to save the configuration node first, deploy your changes, edit it the
       configuration node again, and then the button will be active.
     </p>
+  </div>
+  <div class="form-row hide">
+    <input type="hidden" id="node-config-input-oauth"/>
   </div>
 </script>

--- a/nodes/spotify-api.js
+++ b/nodes/spotify-api.js
@@ -1,5 +1,6 @@
 const SpotifyWebApi = require('spotify-web-api-node');
 const credentialsStore = require("../lib/credentials.js");
+const successPageContent = require("../lib/success-page.js");
 
 module.exports = function (RED) {
   let tokenMap = {};
@@ -56,19 +57,7 @@ module.exports = function (RED) {
 
     if (state !== null && code !== null) {
       tokenMap[state] = code;
-
-      res.send(`
-        <html lang="en">
-        <body>
-          <script type="text/javascript">
-          (() => {
-            setTimeout(() => window.close(), 2500); 
-          })();
-          </script>
-          <h3>Authentication successful, the window will close shortly.</h3>
-        </body>
-        </html>
-        `)
+      res.send(successPageContent)
     }
   });
 


### PR DESCRIPTION
Keep the refresh token in a custom credentials storage. Thanks to this, whenever the refresh token changes (which happens from time to time), it's remembered in the persistent storage, so it can sustain Node-RED restarts.

Force user to save and deploy the configuration node before triggering OAuth flow. Thanks to this, the secret is safely stored inside Node-RED configuration, and it's a less chance for it to leak.

The OAuth's redirect page has been slightly improved, so it doesn't look like a scam (that much).